### PR TITLE
Fix endianness issues in MMU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ run-all-tests: lib68-test-target
 
 .PHONY: clean
 clean:
-	-rm -v $(TEST-OBJECTS) $(LIB-OBJECTS) lib68.a
+	-rm -v $(TEST-OBJECTS) $(LIB-OBJECTS) lib68.a libUnit/unit.o
+	-make -C libUnit clean
 
 # Test Target Related
 

--- a/cpu/endian.h
+++ b/cpu/endian.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Tom Hancocks, The Diamond Project
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if !defined(lib68_Endian)
+#	if defined(__clang__)
+
+#	elif defined(__GNUC__) || defined(__GNUG__)
+#		if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#			define __LITTLE_ENDIAN__
+#		elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#			define __BIG_ENDIAN
+#		else
+#			error Unsupported architecture.
+#		endif
+#	else
+#		error Compiler not supported.	
+#	endif
+#endif

--- a/cpu/endian.h
+++ b/cpu/endian.h
@@ -22,7 +22,6 @@
 
 #if !defined(lib68_Endian)
 #	if defined(__clang__)
-
 #	elif defined(__GNUC__) || defined(__GNUG__)
 #		if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #			define __LITTLE_ENDIAN__
@@ -34,4 +33,17 @@
 #	else
 #		error Compiler not supported.	
 #	endif
+
+#	if defined(__BIG_ENDIAN__)
+#		define TO_BIG_WORD(_V) (_V)
+#		define TO_BIG_LONG(_V) (_V)
+#		define FROM_BIG_WORD(_V) (_V)
+#		define FROM_BIG_LONG(_V) (_V)
+#	elif defined(__LITTLE_ENDIAN__)
+#		define TO_BIG_WORD(_V) (((_V & 0xFF00) >> 8) | ((_V & 0x00FF) << 8))
+#		define TO_BIG_LONG(_V) (((_V & 0xFF000000) >> 24) | ((_V & 0x000000FF) << 24) | ((_V & 0x0000FF00) << 8) | ((_V & 0x00FF0000) >> 8))
+#		define FROM_BIG_WORD(_V) TO_BIG_WORD((_V))
+#		define FROM_BIG_LONG(_V) TO_BIG_LONG((_V))
+#	endif
+
 #endif

--- a/cpu/mmu.c
+++ b/cpu/mmu.c
@@ -59,7 +59,7 @@ void m68_mmu_destroy(void)
 			}
 
 			/* Fetch the page table */
-			union m68_mmu_page_entry *PAGE_TABLE = (void *)(MMU_PAGE_DIR[i].field.address << 4);
+			union m68_mmu_page_entry *PAGE_TABLE = (void *)((uintptr_t)MMU_PAGE_DIR[i].field.address << 4);
 
 			/* Iterate over all pages in the table */
 			for (int j = 0; j < MMU_PAGE_TABLE_MAX_ENTRIES; ++j) {
@@ -68,7 +68,7 @@ void m68_mmu_destroy(void)
 				}
 
 				/* Fetch the page */
-				void *PAGE = (void *)(PAGE_TABLE[i].field.address << 4);
+				void *PAGE = (void *)((uintptr_t)PAGE_TABLE[i].field.address << 4);
 				free(PAGE);
 			}
 
@@ -103,10 +103,10 @@ void *m68_mmu_page_alloc(uint32_t address)
 			table = (void *)address;
 		}
 
-		MMU_PAGE_DIR[dir_idx].field.address = (address >> 2) & ~0xF;
+		MMU_PAGE_DIR[dir_idx].field.address = (address >> 2);
 		MMU_PAGE_DIR[dir_idx].field.present = 1;
 	} else {
-		table = (void *)(MMU_PAGE_DIR[dir_idx].field.address << 2);
+		table = (void *)((uintptr_t)MMU_PAGE_DIR[dir_idx].field.address << 2);
 	}
 
 	/* Now check for the presence of the desired page in the table. If the page
@@ -119,10 +119,10 @@ void *m68_mmu_page_alloc(uint32_t address)
 			page = (void *)address;
 		}
 
-		table[table_idx].field.address = (address >> 2) & ~0xF;
+		table[table_idx].field.address = (address >> 2);
 		table[table_idx].field.present = 1;
 	} else {
-		page = (void *)(table[table_idx].field.address << 2);
+		page = (void *)((uintptr_t)table[table_idx].field.address << 2);
 	}
 
 	return page;

--- a/cpu/mmu.c
+++ b/cpu/mmu.c
@@ -21,6 +21,7 @@
  */
 
 #include "cpu/mmu.h"
+#include "cpu/endian.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <arpa/inet.h>

--- a/cpu/mmu.c
+++ b/cpu/mmu.c
@@ -29,56 +29,6 @@
 #define MMU_PAGE_DIR_MAX_ENTRIES	1024
 #define MMU_PAGE_TABLE_MAX_ENTRIES 	1024
 
-// MARK: - Endian Swap Functions
-
-#if defined(__BIG_ENDIAN__)
-
-static inline uint16_t swap_host_word(uint16_t v)
-{
-	return v;
-}
-
-static inline uint32_t swap_host_long(uint32_t v)
-{
-	return v;
-}
-
-static inline uint16_t swap_mmu_word(uint16_t v)
-{
-	return v;
-}
-
-static inline uint32_t swap_mmu_long(uint32_t v)
-{
-	return v;
-}
-
-#elif defined(__LITTLE_ENDIAN__)
-
-static inline uint16_t swap_host_word(uint16_t v)
-{
-	return ((v >> 8) & 0xFF) | ((v & 0xFF) << 8);
-}
-
-static inline uint32_t swap_host_long(uint32_t v)
-{
-	return ((v >> 24) & 0xFF) | ((v >> 8) & 0xFF00) | ((v << 8) & 0xFF0000) | ((v << 24) & 0xFF000000);
-}
-
-static inline uint16_t swap_mmu_word(uint16_t v)
-{
-	return swap_host_word(v);
-}
-
-static inline uint32_t swap_mmu_long(uint32_t v)
-{
-	return swap_host_long(v);
-}
-
-#else
-#	error Unknown architecture - unable to compile for.
-#endif
-
 // MARK: - Initialisation & Destruction
 
 int m68_mmu_initialise(void)
@@ -196,7 +146,7 @@ void m68_mmu_write_byte(uint32_t address, uint8_t value)
 void m68_mmu_write_word(uint32_t address, uint16_t value)
 {
 	uint8_t *ptr = m68_mmu_translate(address);
-	value = swap_host_word(value);
+	value = TO_BIG_WORD(value);
 	*(ptr + 1) = (value >> 8);
 	*(ptr + 0) = value;
 }
@@ -204,7 +154,7 @@ void m68_mmu_write_word(uint32_t address, uint16_t value)
 void m68_mmu_write_long(uint32_t address, uint32_t value)
 {
 	uint8_t *ptr = m68_mmu_translate(address);
-	value = swap_host_long(value);
+	value = TO_BIG_LONG(value);
 	*(ptr + 3) = (value >> 24);
 	*(ptr + 2) = (value >> 16);
 	*(ptr + 1) = (value >> 8);
@@ -222,13 +172,13 @@ uint8_t m68_mmu_read_byte(uint32_t address)
 uint16_t m68_mmu_read_word(uint32_t address)
 {
 	uint8_t *ptr = m68_mmu_translate(address);
-	uint16_t value = (ptr[0] << 8) | ptr[1];
-	return swap_mmu_word(value);
+	uint16_t value = (*(ptr + 1) << 8) | *(ptr + 0);
+	return FROM_BIG_WORD(value);
 }
 
 uint32_t m68_mmu_read_long(uint32_t address)
 {
 	uint8_t *ptr = m68_mmu_translate(address);
-	uint32_t value = (ptr[0] << 24) | (ptr[1] << 16) | (ptr[2] << 8) | ptr[3];
-	return swap_mmu_long(value);
+	uint32_t value = (*(ptr + 3) << 24) | (*(ptr + 2) << 16) | (*(ptr + 1) << 8) | *(ptr + 0);
+	return FROM_BIG_LONG(value);
 }

--- a/tests/mmu.c
+++ b/tests/mmu.c
@@ -49,38 +49,42 @@ TEST_CASE(MMU, WriteByteToMemory)
 {
 	m68_mmu_initialise();
 
-	uint8_t *page = m68_mmu_page_alloc(0x0000);
+	uint8_t *ptr = m68_mmu_page_alloc(0x0000);
 	m68_mmu_write_byte(0x3, 0xCD);
 
-	ASSERT_EQ(page[3], 0xCD);
+	ASSERT_EQ(*(ptr + 3), 0xCD);
 }
 
 TEST_CASE(MMU, WriteWordToMemory)
 {
 	m68_mmu_initialise();
 
-	uint16_t *page = m68_mmu_page_alloc(0x0000);
+	uint8_t *ptr = m68_mmu_page_alloc(0x0000);
 	m68_mmu_write_word(0x0, 0xDEAD);
 
-	ASSERT_EQ(page[0], 0xADDE);
+	ASSERT_EQ(*(ptr + 0), 0xDE);
+	ASSERT_EQ(*(ptr + 1), 0xAD);
 }
 
 TEST_CASE(MMU, WriteLongToMemory)
 {
 	m68_mmu_initialise();
 
-	uint32_t *page = m68_mmu_page_alloc(0x0000);
+	uint8_t *ptr = m68_mmu_page_alloc(0x0000);
 	m68_mmu_write_long(0x0, 0xDEADBEEF);
 
-	ASSERT_EQ(page[0], 0xEFBEADDE);
+	ASSERT_EQ(*(ptr + 0), 0xDE);
+	ASSERT_EQ(*(ptr + 1), 0xAD);
+	ASSERT_EQ(*(ptr + 2), 0xBE);
+	ASSERT_EQ(*(ptr + 3), 0xEF);
 }
 
 TEST_CASE(MMU, ReadByteFromMemory)
 {
 	m68_mmu_initialise();
 
-	uint8_t *page = m68_mmu_page_alloc(0x0000);
-	page[0] = 0xDE;
+	uint8_t *ptr = m68_mmu_page_alloc(0x0000);
+	*(ptr + 0) = 0xDE;
 
 	ASSERT_EQ(m68_mmu_read_byte(0x0), 0xDE);
 }
@@ -89,24 +93,24 @@ TEST_CASE(MMU, ReadWordFromMemory)
 {
 	m68_mmu_initialise();
 
-	uint8_t *page = m68_mmu_page_alloc(0x0000);
-	page[0] = 0xDE;
-	page[1] = 0xAD;
+	uint8_t *ptr = m68_mmu_page_alloc(0x0000);
+	*(ptr + 0) = 0xDE;
+	*(ptr + 1) = 0xAD;
 
-	ASSERT_EQ(m68_mmu_read_word(0x0), 0xADDE);
+	ASSERT_EQ(m68_mmu_read_word(0x0), 0xDEAD);
 }
 
 TEST_CASE(MMU, ReadLongFromMemory)
 {
 	m68_mmu_initialise();
 
-	uint8_t *page = m68_mmu_page_alloc(0x0000);
-	page[0] = 0xDE;
-	page[1] = 0xAD;
-	page[2] = 0xBE;
-	page[3] = 0xEF;
+	uint8_t *ptr = m68_mmu_page_alloc(0x0000);
+	*(ptr + 0) = 0xDE;
+	*(ptr + 1) = 0xAD;
+	*(ptr + 2) = 0xBE;
+	*(ptr + 3) = 0xEF;
 
-	ASSERT_EQ(m68_mmu_read_long(0x0), 0xEFBEADDE);
+	ASSERT_EQ(m68_mmu_read_long(0x0), 0xDEADBEEF);
 }
 
 #endif

--- a/tests/mmu.c
+++ b/tests/mmu.c
@@ -62,7 +62,7 @@ TEST_CASE(MMU, WriteWordToMemory)
 	uint16_t *page = m68_mmu_page_alloc(0x0000);
 	m68_mmu_write_word(0x0, 0xDEAD);
 
-	ASSERT_EQ(page[0], 0xDEAD);
+	ASSERT_EQ(page[0], 0xADDE);
 }
 
 TEST_CASE(MMU, WriteLongToMemory)
@@ -72,7 +72,7 @@ TEST_CASE(MMU, WriteLongToMemory)
 	uint32_t *page = m68_mmu_page_alloc(0x0000);
 	m68_mmu_write_long(0x0, 0xDEADBEEF);
 
-	ASSERT_EQ(page[0], 0xDEADBEEF);
+	ASSERT_EQ(page[0], 0xEFBEADDE);
 }
 
 TEST_CASE(MMU, ReadByteFromMemory)
@@ -93,7 +93,7 @@ TEST_CASE(MMU, ReadWordFromMemory)
 	page[0] = 0xDE;
 	page[1] = 0xAD;
 
-	ASSERT_EQ(m68_mmu_read_word(0x0), 0xDEAD);
+	ASSERT_EQ(m68_mmu_read_word(0x0), 0xADDE);
 }
 
 TEST_CASE(MMU, ReadLongFromMemory)
@@ -106,7 +106,7 @@ TEST_CASE(MMU, ReadLongFromMemory)
 	page[2] = 0xBE;
 	page[3] = 0xEF;
 
-	ASSERT_EQ(m68_mmu_read_long(0x0), 0xDEADBEEF);
+	ASSERT_EQ(m68_mmu_read_long(0x0), 0xEFBEADDE);
 }
 
 #endif


### PR DESCRIPTION
The Memory Management Unit exhibits unexpected behaviour when compiled with GCC on Linux systems. This PR is intended to fix those issues and introduce a portable handling of endianness in the emulation.